### PR TITLE
plugins-api: fix combat level updating

### DIFF
--- a/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
+++ b/game/plugins/src/main/kotlin/gg/rsmod/plugins/api/ext/PlayerExt.kt
@@ -567,8 +567,8 @@ fun Player.calculateAndSetCombatLevel(): Boolean {
     val changed = combatLevel != old
     runClientScript(3954, 46661634, 46661635, combatLevel)
     if (changed) {
-        runClientScript(389, combatLevel)
         sendCombatLevelText()
+        runClientScript(389)
         addBlock(UpdateBlockType.APPEARANCE)
         return true
     }


### PR DESCRIPTION
Script 389 doesn't take an argument, it reads the varbit that is set in sendCombatLevelText().

So we call that first and drop the argument