### PR TITLE
Some fixes for 213

### DIFF
--- a/data/packets.yml
+++ b/data/packets.yml
@@ -1567,3 +1567,15 @@ client-packets:
     type: VARIABLE_BYTE
     opcode: 17
     ignore: true
+
+  - message: org.alter.game.message.impl.EventMouseClickMessage
+    type: FIXED
+    opcode: 13
+    length: 6
+    structure:
+      - name: ignored
+        type: SHORT
+      - name: x
+        type: SHORT
+      - name: y
+        type: SHORT

--- a/data/packets.yml
+++ b/data/packets.yml
@@ -973,16 +973,20 @@ client-packets:
       - name: x
         type: SHORT
         order: LITTLE
+        sign: UNSIGNED
       - name: movement_type
         type: BYTE
         trans: ADD
+        sign: UNSIGNED
       - name: z
         type: SHORT
         trans: ADD
         order: LITTLE
+        sign: UNSIGNED
       - name: id
         type: SHORT
         trans: ADD
+        sign: UNSIGNED
 
   - message: org.alter.game.message.impl.OpLoc2Message
     type: FIXED
@@ -993,16 +997,20 @@ client-packets:
         type: SHORT
         trans: ADD
         order: LITTLE
+        sign: UNSIGNED
       - name: z
         type: SHORT
         order: LITTLE
+        sign: UNSIGNED
       - name: id
         type: SHORT
         trans: ADD
         order: LITTLE
+        sign: UNSIGNED
       - name: movement_type
         type: BYTE
         trans: SUBTRACT
+        sign: UNSIGNED
 
   - message: org.alter.game.message.impl.OpLoc3Message
     type: FIXED
@@ -1013,16 +1021,20 @@ client-packets:
         type: SHORT
         trans: ADD
         order: LITTLE
+        sign: UNSIGNED
       - name: id
         type: SHORT
         order: LITTLE
+        sign: UNSIGNED
       - name: z
         type: SHORT
         trans: ADD
         order: LITTLE
+        sign: UNSIGNED
       - name: movement_type
         type: BYTE
         trans: NEGATE
+        sign: UNSIGNED
 
   - message: org.alter.game.message.impl.OpLoc4Message
     type: FIXED
@@ -1032,15 +1044,19 @@ client-packets:
       - name: id
         type: SHORT
         trans: ADD
+        sign: UNSIGNED
       - name: movement_type
         type: BYTE
         trans: ADD
+        sign: UNSIGNED
       - name: z
         type: SHORT
         trans: ADD
+        sign: UNSIGNED
       - name: x
         type: SHORT
         order: LITTLE
+        sign: UNSIGNED
 
   - message: org.alter.game.message.impl.OpLoc5Message
     type: FIXED
@@ -1108,6 +1124,7 @@ client-packets:
         type: SHORT
         trans: ADD
         order: LITTLE
+        sign: UNSIGNED
 
   - message: org.alter.game.message.impl.CloseModalMessage
     type: FIXED

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/inventory/Inventory.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/inventory/Inventory.plugin.kts
@@ -53,7 +53,7 @@ on_button(InterfaceDestination.INVENTORY.interfaceId, 0) {
 /**
  * Logic for swapping items in inventory.
  */
-on_component_item_swap(interfaceId = 149, component = 0) {
+on_component_to_component_item_swap(srcInterfaceId = 149, srcComponent = 0, dstInterfaceId = 149, 0) {
     val srcSlot = player.attr[INTERACTING_ITEM_SLOT]!!
     val dstSlot = player.attr[OTHER_ITEM_SLOT_ATTR]!!
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/prayer/Prayer.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/prayer/Prayer.kt
@@ -4,8 +4,8 @@ package org.alter.plugins.content.mechanics.prayer
  * @author Tom <rspsmods@gmail.com>
  */
 enum class Prayer(val named: String, val child: Int, val quickPrayerSlot: Int, val varbit: Int,
-                  val level: Int, val sound: Int, val drainEffect: Int, val group: PrayerGroup?,
-                  vararg val overlap: PrayerGroup) {
+                  val level: Int, val defenceLevel: Int = 1, val sound: Int, val drainEffect: Int,
+                  val group: PrayerGroup?, vararg val overlap: PrayerGroup) {
 
     THICK_SKIN(named = "Thick Skin", child = 9, quickPrayerSlot = 0, varbit = 4104, level = 1, sound = 2690, drainEffect = 3,
             group = PrayerGroup.DEFENCE, overlap = arrayOf(PrayerGroup.COMBAT)),
@@ -19,7 +19,7 @@ enum class Prayer(val named: String, val child: Int, val quickPrayerSlot: Int, v
     SHARP_EYE(named = "Sharp Eye", child = 27, quickPrayerSlot = 18, varbit = 4122, level = 8, sound = 2685, drainEffect = 3,
             group = PrayerGroup.RANGED, overlap = arrayOf(PrayerGroup.ATTACK, PrayerGroup.STRENGTH, PrayerGroup.MAGIC, PrayerGroup.COMBAT)),
 
-    MYSTIC_WILL(named = "Mystic Will", child = 28, quickPrayerSlot = 19, varbit = 4123, level = 9, sound = 2670, drainEffect = 3,
+    MYSTIC_WILL(named = "Mystic Will", child = 30, quickPrayerSlot = 19, varbit = 4123, level = 9, sound = 2670, drainEffect = 3,
             group = PrayerGroup.MAGIC, overlap = arrayOf(PrayerGroup.ATTACK, PrayerGroup.STRENGTH, PrayerGroup.RANGED, PrayerGroup.COMBAT)),
 
     ROCK_SKIN(named = "Rock Skin", child = 12, quickPrayerSlot = 3, varbit = 4107, level = 10, sound = 2684, drainEffect = 6,
@@ -40,10 +40,10 @@ enum class Prayer(val named: String, val child: Int, val quickPrayerSlot: Int, v
     PROTECT_ITEM(named = "Protect Item", child = 17, quickPrayerSlot = 8, varbit = 4112, level = 25, sound = 1982, drainEffect = 2,
             group = null, overlap = arrayOf()),
 
-    HAWK_EYE(named = "Hawk Eye", child = 29, quickPrayerSlot = 20, varbit = 4124, level = 26, sound = 2666, drainEffect = 6,
+    HAWK_EYE(named = "Hawk Eye", child = 28, quickPrayerSlot = 20, varbit = 4124, level = 26, sound = 2666, drainEffect = 6,
             group = PrayerGroup.RANGED, overlap = arrayOf(PrayerGroup.ATTACK, PrayerGroup.STRENGTH, PrayerGroup.MAGIC, PrayerGroup.COMBAT)),
 
-    MYSTIC_LORE(named = "Mystic Lore", child = 30, quickPrayerSlot = 21, varbit = 4125, level = 27, sound = 2668, drainEffect = 6,
+    MYSTIC_LORE(named = "Mystic Lore", child = 31, quickPrayerSlot = 21, varbit = 4125, level = 27, sound = 2668, drainEffect = 6,
             group = PrayerGroup.MAGIC, overlap = arrayOf(PrayerGroup.ATTACK, PrayerGroup.STRENGTH, PrayerGroup.RANGED, PrayerGroup.COMBAT)),
 
     STEEL_SKIN(named = "Steel Skin", child = 18, quickPrayerSlot = 9, varbit = 4113, level = 28, sound = 2687, drainEffect = 12,
@@ -64,7 +64,7 @@ enum class Prayer(val named: String, val child: Int, val quickPrayerSlot: Int, v
     PROTECT_FROM_MELEE(named = "Protect from Melee", child = 23, quickPrayerSlot = 14, varbit = 4118, level = 43, sound = 2676, drainEffect = 12,
             group = PrayerGroup.OVERHEAD, overlap = arrayOf()),
 
-    EAGLE_EYE(named = "Eagle Eye", child = 31, quickPrayerSlot = 22, varbit = 4126, level = 44, sound = 2665, drainEffect = 12,
+    EAGLE_EYE(named = "Eagle Eye", child = 29, quickPrayerSlot = 22, varbit = 4126, level = 44, sound = 2665, drainEffect = 12,
             group = PrayerGroup.RANGED, overlap = arrayOf(PrayerGroup.ATTACK, PrayerGroup.STRENGTH, PrayerGroup.MAGIC, PrayerGroup.COMBAT)),
 
     MYSTIC_MIGHT(named = "Mystic Might", child = 32, quickPrayerSlot = 23, varbit = 4127, level = 45, sound = 2669, drainEffect = 12,
@@ -82,16 +82,16 @@ enum class Prayer(val named: String, val child: Int, val quickPrayerSlot: Int, v
     PRESERVE(named = "Preserve", child = 37, quickPrayerSlot = 28, varbit = 5466, level = 55, sound = 3825, drainEffect = 3,
             group = null, overlap = arrayOf()),
 
-    CHIVALRY(named = "Chivalry", child = 33, quickPrayerSlot = 25, varbit = 4128, level = 60, sound = 3826, drainEffect = 24,
+    CHIVALRY(named = "Chivalry", child = 34, quickPrayerSlot = 25, varbit = 4128, level = 60, defenceLevel = 65, sound = 3826, drainEffect = 24,
             group = PrayerGroup.COMBAT, overlap = arrayOf(PrayerGroup.ATTACK, PrayerGroup.STRENGTH, PrayerGroup.DEFENCE, PrayerGroup.RANGED, PrayerGroup.MAGIC)),
 
-    PIETY(named = "Piety", child = 34, quickPrayerSlot = 26, varbit = 4129, level = 70, sound = 3825, drainEffect = 24,
+    PIETY(named = "Piety", child = 35, quickPrayerSlot = 26, varbit = 4129, level = 70, defenceLevel = 70, sound = 3825, drainEffect = 24,
             group = PrayerGroup.COMBAT, overlap = arrayOf(PrayerGroup.ATTACK, PrayerGroup.STRENGTH, PrayerGroup.DEFENCE, PrayerGroup.RANGED, PrayerGroup.MAGIC)),
 
-    RIGOUR(named = "Rigour", child = 35, quickPrayerSlot = 24, varbit = 5464, level = 74, sound = 3825, drainEffect = 24,
+    RIGOUR(named = "Rigour", child = 33, quickPrayerSlot = 24, varbit = 5464, level = 74, defenceLevel = 70, sound = 3825, drainEffect = 24,
             group = PrayerGroup.COMBAT, overlap = arrayOf(PrayerGroup.ATTACK, PrayerGroup.STRENGTH, PrayerGroup.DEFENCE, PrayerGroup.RANGED, PrayerGroup.MAGIC)),
 
-    AUGURY(named = "Augury", child = 36, quickPrayerSlot = 27, varbit = 5465, level = 77, sound = 3825, drainEffect = 24,
+    AUGURY(named = "Augury", child = 36, quickPrayerSlot = 27, varbit = 5465, level = 77, defenceLevel = 70, sound = 3825, drainEffect = 24,
             group = PrayerGroup.COMBAT, overlap = arrayOf(PrayerGroup.ATTACK, PrayerGroup.STRENGTH, PrayerGroup.DEFENCE, PrayerGroup.RANGED, PrayerGroup.MAGIC)),
     ;
 

--- a/game-server/src/main/kotlin/org/alter/game/message/MessageDecoderSet.kt
+++ b/game-server/src/main/kotlin/org/alter/game/message/MessageDecoderSet.kt
@@ -35,6 +35,7 @@ class MessageDecoderSet {
         put(EventCameraPositionMessage::class.java, EventCameraPositionDecoder(), EventCameraPositionHandler(), structures)
         put(EventMouseIdleMessage::class.java, EventMouseIdleDecoder(), EventMouseIdleHandler(), structures)
         put(EventKeyboardMessage::class.java, EventKeyboardDecoder(), EventKeyboardHandler(), structures)
+        put(EventMouseClickMessage::class.java, EventMouseClickDecoder(), EventMouseClickHandler(), structures)
 
         put(DetectModifiedClientMessage::class.java, DetectModifiedClientDecoder(), DetectModifiedClientHandler(), structures)
         put(MessagePublicMessage::class.java, MessagePublicDecoder(), MessagePublicHandler(), structures)

--- a/game-server/src/main/kotlin/org/alter/game/message/decoder/EventMouseClickDecoder.kt
+++ b/game-server/src/main/kotlin/org/alter/game/message/decoder/EventMouseClickDecoder.kt
@@ -1,0 +1,17 @@
+package org.alter.game.message.decoder
+
+import org.alter.game.message.MessageDecoder
+import org.alter.game.message.impl.EventMouseClickMessage
+
+/**
+ * @author Tom <rspsmods@gmail.com>
+ */
+class EventMouseClickDecoder : MessageDecoder<EventMouseClickMessage>() {
+
+    override fun decode(opcode: Int, opcodeIndex: Int, values: HashMap<String, Number>, stringValues: HashMap<String, String>): EventMouseClickMessage {
+        val x = values["x"]!!.toInt()
+        val y = values["y"]!!.toInt()
+
+        return EventMouseClickMessage(x, y)
+    }
+}

--- a/game-server/src/main/kotlin/org/alter/game/message/handler/EventMouseClickHandler.kt
+++ b/game-server/src/main/kotlin/org/alter/game/message/handler/EventMouseClickHandler.kt
@@ -1,0 +1,15 @@
+package org.alter.game.message.handler
+
+import org.alter.game.message.MessageHandler
+import org.alter.game.message.impl.EventMouseClickMessage
+import org.alter.game.model.World
+import org.alter.game.model.entity.Client
+
+/**
+ * @author Tom <rspsmods@gmail.com>
+ */
+class EventMouseClickHandler : MessageHandler<EventMouseClickMessage> {
+    override fun handle(client: Client, world: World, message: EventMouseClickMessage) {
+        // TODO
+    }
+}

--- a/game-server/src/main/kotlin/org/alter/game/message/impl/EventMouseClickMessage.kt
+++ b/game-server/src/main/kotlin/org/alter/game/message/impl/EventMouseClickMessage.kt
@@ -1,0 +1,8 @@
+package org.alter.game.message.impl
+
+import org.alter.game.message.Message
+
+/**
+ * @author Tom <rspsmods@gmail.com>
+ */
+data class EventMouseClickMessage(val x: Int, val y: Int) : Message

--- a/game-server/src/main/kotlin/org/alter/game/sync/segment/PlayerUpdateBlockSegment.kt
+++ b/game-server/src/main/kotlin/org/alter/game/sync/segment/PlayerUpdateBlockSegment.kt
@@ -162,7 +162,12 @@ class PlayerUpdateBlockSegment(val other: Player, private val newPlayer: Boolean
                             if (translation[i] == -1) {
                                 appBuf.put(DataType.BYTE, 0)
                             } else {
-                                appBuf.put(DataType.SHORT, 0x100 + other.appearance.getLook(translation[i]))
+                                val look = other.appearance.getLook(translation[i])
+                                if (look == -1) {
+                                    appBuf.put(DataType.BYTE, 0)
+                                } else {
+                                    appBuf.put(DataType.SHORT, 0x100 + look)
+                                }
                             }
                         } else {
                             appBuf.put(DataType.SHORT, 0x200 + item.id)


### PR DESCRIPTION
- Fix issue with syncing appearance data for females who're missing beard data in the array.
    - Because the female `appearance` array has 1 less value, because it has no beard value, `getLook` was returning `-1` which should be sent as `0`, but was being sent as `0x100 + -1`. The result was that render animations, username, combat level were all messed up.
    - Proposed solution: when `getLook` returns `-1`, just send `0` instead of the messed up `0x100 + -1`
- Add EventMouseClick packet handling
    - Not sure if this is needed, but I've found it handy to have access to.
- Use `on_component_to_component_item_swap` instead of `on_component_item_swap` for inventory item swapping.
- Fix Prayer component IDs, as they were just mixed up a bit.
- Fix OpLoc1/2/3/4/6 packets - should all be unsigned apparently.
    - Unsure what's up with option 5. Ignoring for now, brain isn't working. Looking at the client side, you'd think it's all unsigned too.