### PR TITLE
Fix `RebuildRegionMessage` for loading into instanced maps.

### DIFF
--- a/data/packets.yml
+++ b/data/packets.yml
@@ -332,7 +332,7 @@ server-packets:
         trans: ADD
         order: LITTLE
       - name: data
-        type: SHORT
+        type: BYTES
 
   - message: org.alter.game.message.impl.UpdateZonePartialFollowsMessage
     type: FIXED


### PR DESCRIPTION
Change RebuildRegionMessage `data` type to be `BYTES` instead of `SHORT` so all the data actually gets sent when moving into instanced map.

`RebuildRegionEncoder` writes a bunch of data to a `ByteArray` for `data`, but `packets.yml` having the type as `SHORT` i think was resulting in all of the bytes past the first two not being sent.