### PR TITLE
Shop and Al Kharid gate bug fixes

### DIFF
--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/area/lumbridge/objs/alkharidgate/alkharid_gate.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/area/lumbridge/objs/alkharidgate/alkharid_gate.plugin.kts
@@ -7,12 +7,13 @@ package org.alter.plugins.content.area.lumbridge.objs.alkharidgate
 val GATES = intArrayOf(Objs.GATE_44052, Objs.GATE_44053)
 
 GATES.forEach { obj ->
-    on_obj_option(obj, "pay-toll(10gp)", lineOfSightDistance = 2) {
+    on_obj_option(obj, "pay-toll(10gp)", lineOfSightDistance = 1) {
         if (player.inventory.getItemCount(Items.COINS_995) >= 10) {
             if (obj == 44053) {
-                player.lock()
                 if (player.tile.x == 3268 && player.tile.z == 3227) {
+                    player.lock()
                     player.moveTo(3268, 3228, 0)
+                    player.unlock()
                 }
                 world.queue {
                     world.openDoor(world.getObject(Tile(3268, 3228), 0)!!, 1574)
@@ -24,14 +25,16 @@ GATES.forEach { obj ->
                 val curr = player.tile
                 val dst = if (curr.sameAs(3267, 3228)) Tile(3268, 3228) else if (curr.sameAs(3268, 3228)) Tile(3267, 3228) else return@on_obj_option
                 player.inventory.remove(Items.COINS_995, 10)
+                player.lock()
                 player.moveTo(dst)
                 player.unlock()
             }
 
             if (obj == 44052) {
-                player.lock()
                 if (player.tile.x == 3268 && player.tile.z == 3228) {
+                    player.lock()
                     player.moveTo(3268, 3227, 0)
+                    player.unlock()
                 }
                 world.queue {
                     world.openDoor(world.getObject(Tile(3268, 3228), 0)!!, 1574)
@@ -43,6 +46,7 @@ GATES.forEach { obj ->
                 val curr = player.tile
                 val dst = if (curr.sameAs(3267, 3227)) Tile(3268, 3227) else if (curr.sameAs(3268, 3227)) Tile(3267, 3227) else return@on_obj_option
                 player.inventory.remove(Items.COINS_995, 10)
+                player.lock()
                 player.moveTo(dst)
                 player.unlock()
             }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/shops/shops.plugin.kts
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/shops/shops.plugin.kts
@@ -35,14 +35,14 @@ on_button(interfaceId = SHOP_INTERFACE_ID, component = 16) {
         val shopItem = shop.items[slot] ?: return@on_button
 
         when (opt) {
-            1 -> shop.currency.onSellValueMessage(player, shopItem)
-            10 -> world.sendExamine(player, shopItem.item, ExamineEntityType.ITEM)
+            0 -> shop.currency.onSellValueMessage(player, shopItem)
+            9 -> world.sendExamine(player, shopItem.item, ExamineEntityType.ITEM)
             else -> {
                 val amount = when (opt) {
-                    2 -> BUY_OPTS[0]
-                    3 -> BUY_OPTS[1]
-                    4 -> BUY_OPTS[2]
-                    5 -> BUY_OPTS[3]
+                    1 -> BUY_OPTS[0]
+                    2 -> BUY_OPTS[1]
+                    3 -> BUY_OPTS[2]
+                    4 -> BUY_OPTS[3]
                     else -> return@on_button
                 }
                 shop.currency.sellToPlayer(player, shop, slot, amount)
@@ -58,14 +58,14 @@ on_button(interfaceId = INV_INTERFACE_ID, component = 0) {
         val item = player.inventory[slot] ?: return@on_button
 
         when (opt) {
-            1 -> shop.currency.onBuyValueMessage(player, shop, item.id)
-            10 -> world.sendExamine(player, item.id, ExamineEntityType.ITEM)
+            0 -> shop.currency.onBuyValueMessage(player, shop, item.id)
+            9 -> world.sendExamine(player, item.id, ExamineEntityType.ITEM)
             else -> {
                 val amount = when (opt) {
-                    2 -> SELL_OPTS[0]
-                    3 -> SELL_OPTS[1]
-                    4 -> SELL_OPTS[2]
-                    5 -> SELL_OPTS[3]
+                    1 -> SELL_OPTS[0]
+                    2 -> SELL_OPTS[1]
+                    3 -> SELL_OPTS[2]
+                    4 -> SELL_OPTS[3]
                     else -> return@on_button
                 }
                 shop.currency.buyFromPlayer(player, shop, slot, amount)


### PR DESCRIPTION
Currently shop menu indices are 1 value higher than expected, so value is returned from buy 1, buy 1 is returned from buy 5, etc.

Al Kharid gate could cause the player to be unable to move when accessed from more than one tile away on the east side.