### PR TITLE
refactor: start reworking queuetask

### DIFF
--- a/game-api/src/main/kotlin/org/alter/api/ext/InventoryExt.kt
+++ b/game-api/src/main/kotlin/org/alter/api/ext/InventoryExt.kt
@@ -298,6 +298,7 @@ fun Player.comboItemReplace(
 }
 
 fun Player.produceItemBoxMessage(
+    player: Player,
     vararg itemsToMake: Int,
     title: String = if (itemsToMake.size == 1) "How many do you wish to make?" else "What would you like to make?",
     max: Int = inventory.capacity,
@@ -315,7 +316,7 @@ fun Player.produceItemBoxMessage(
         }
         else -> {
             queue {
-                produceItemBox(*itemsToMake, title = title, maxProducable = max) { _, qty ->
+                produceItemBox(player, *itemsToMake, title = title, maxProducable = max) { _, qty ->
                     player.queue {
                         repeat(qty) {
                             if (growingDelay) wait(Math.min(1 + it, 2)) else wait(1) // insures production tasks are not spammed

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/combat/CombatPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/combat/CombatPlugin.kt
@@ -10,6 +10,7 @@ import org.alter.game.model.attr.COMBAT_TARGET_FOCUS_ATTR
 import org.alter.game.model.attr.FACING_PAWN_ATTR
 import org.alter.game.model.attr.INTERACTING_PLAYER_ATTR
 import org.alter.game.model.entity.Npc
+import org.alter.game.model.entity.Pawn
 import org.alter.game.model.entity.Player
 import org.alter.game.model.move.MovementQueue.StepType
 import org.alter.game.model.move.hasMoveDestination
@@ -37,7 +38,7 @@ class CombatPlugin(
             pawn.queue {
                 while (true) {
                     // @TODO Npc can follow player up to 16 tiles from spawn point, some npc will have exceptional range so property for overwrite should be added.
-                    if (!cycle(this)) {
+                    if (!cycle(pawn, this)) {
                         break
                     }
                     wait(1)
@@ -54,8 +55,7 @@ class CombatPlugin(
     /**
      * @TODO Bigger creatures seem to have bugged range + their route finding sucks due to conditions given.
      */
-    suspend fun cycle(queue: QueueTask): Boolean {
-        val pawn = queue.pawn
+    suspend fun cycle(pawn: Pawn, queue: QueueTask): Boolean {
         val target = pawn.getCombatTarget() ?: return false
         val strategy = CombatConfigs.getCombatStrategy(pawn)
         val attackRange = strategy.getAttackRange(pawn)
@@ -141,7 +141,7 @@ class CombatPlugin(
             if (!target.isAlive()) {
                 return false
             }
-            return cycle(queue)
+            return cycle(pawn, queue)
         }
         if (!Combat.canEngage(pawn, target)) {
             Combat.reset(pawn)

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/commands/commands/admin/ItemPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/commands/commands/admin/ItemPlugin.kt
@@ -5,6 +5,7 @@ import dev.openrune.cache.CacheManager.itemSize
 import org.alter.api.ext.*
 import org.alter.game.Server
 import org.alter.game.model.World
+import org.alter.game.model.entity.Player
 import org.alter.game.model.item.Item
 import org.alter.game.model.priv.Privilege
 import org.alter.game.model.queue.QueueTask
@@ -37,7 +38,7 @@ class ItemPlugin(
                 }
             } catch (e: Exception) {
                 player.queue(TaskPriority.STRONG) {
-                    val item = spawn() ?: return@queue
+                    val item = spawn(player) ?: return@queue
                     if (item.amount > 0) {
                         player.message("You have spawned ${item.amount} x ${item.getName()}.")
                     } else {
@@ -48,16 +49,16 @@ class ItemPlugin(
         }
     }
 
-    suspend fun QueueTask.spawn(): Item? {
-        val item = searchItemInput("Select an item to spawn:")
+    suspend fun QueueTask.spawn(player: Player): Item? {
+        val item = searchItemInput(player, "Select an item to spawn:")
         if (item == -1) {
             return null
         }
         val amount =
-            when (options("1", "5", "X", "Max", title = "How many would you like to spawn?")) {
+            when (options(player, "1", "5", "X", "Max", title = "How many would you like to spawn?")) {
                 1 -> 1
                 2 -> 5
-                3 -> inputInt("Enter amount to spawn")
+                3 -> inputInt(player, "Enter amount to spawn")
                 4 -> Int.MAX_VALUE
                 else -> return null
             }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/commands/commands/admin/SpawnItemPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/commands/commands/admin/SpawnItemPlugin.kt
@@ -3,6 +3,7 @@ package org.alter.plugins.content.commands.commands.admin
 import org.alter.api.ext.*
 import org.alter.game.Server
 import org.alter.game.model.World
+import org.alter.game.model.entity.Player
 import org.alter.game.model.item.Item
 import org.alter.game.model.priv.Privilege
 import org.alter.game.model.queue.QueueTask
@@ -20,7 +21,7 @@ class SpawnItemPlugin(
 
         onCommand("spawn", Privilege.ADMIN_POWER, description = "Spawn items with ui") {
             player.queue(TaskPriority.STRONG) {
-                val item = spawn() ?: return@queue
+                val item = spawn(player) ?: return@queue
                 if (item.amount > 0) {
                     player.message("You have spawned ${item.amount} x ${item.getName()}.")
                 } else {
@@ -31,7 +32,7 @@ class SpawnItemPlugin(
 
         onCommand("spawn2", Privilege.ADMIN_POWER, description = "Spawn untradable items with ui") {
             player.queue(TaskPriority.STRONG) {
-                val item = spawn2() ?: return@queue
+                val item = spawn2(player) ?: return@queue
                 if (item.amount > 0) {
                     player.message("You have spawned ${item.amount} x ${item.getName()}.")
                 } else {
@@ -41,16 +42,16 @@ class SpawnItemPlugin(
         }
     }
 
-    suspend fun QueueTask.spawn2(): Item? {
-        val item = searchItemInputT("Select an item to spawn:")
+    suspend fun QueueTask.spawn2(player: Player): Item? {
+        val item = searchItemInputT(player, "Select an item to spawn:")
         if (item == -1) {
             return null
         }
         val amount =
-            when (options("1", "5", "X", "Max", title = "How many would you like to spawn?")) {
+            when (options(player, "1", "5", "X", "Max", title = "How many would you like to spawn?")) {
                 1 -> 1
                 2 -> 5
-                3 -> inputInt("Enter amount to spawn")
+                3 -> inputInt(player, "Enter amount to spawn")
                 4 -> Int.MAX_VALUE
                 else -> return null
             }
@@ -58,16 +59,16 @@ class SpawnItemPlugin(
         return Item(item, add.completed)
     }
 
-    suspend fun QueueTask.spawn(): Item? {
-        val item = searchItemInput("Select an item to spawn:")
+    suspend fun QueueTask.spawn(player: Player): Item? {
+        val item = searchItemInput(player, "Select an item to spawn:")
         if (item == -1) {
             return null
         }
         val amount =
-            when (options("1", "5", "X", "Max", title = "How many would you like to spawn?")) {
+            when (options(player, "1", "5", "X", "Max", title = "How many would you like to spawn?")) {
                 1 -> 1
                 2 -> 5
-                3 -> inputInt("Enter amount to spawn")
+                3 -> inputInt(player, "Enter amount to spawn")
                 4 -> Int.MAX_VALUE
                 else -> return null
             }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/commands/commands/developer/ChatanimPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/commands/commands/developer/ChatanimPlugin.kt
@@ -30,7 +30,7 @@ class ChatanimPlugin(
             val npcId = args[1].toInt()
 
             player.queue {
-                chatNpc("Hello World", npcId, animation = key, "hi")
+                chatNpc(player, "Hello World", npcId, animation = key, "hi")
             }
             player.message("$key opened in a dialog", ChatMessageType.ENGINE)
         }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/bank/BankPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/bank/BankPlugin.kt
@@ -221,7 +221,7 @@ class BankPlugin(
                 amount = player.inventory.getItemCount(item.id)
             } else if (amount == -1) {
                 player.queue(TaskPriority.WEAK) {
-                    amount = inputInt("How many would you like to bank?")
+                    amount = inputInt(player, "How many would you like to bank?")
                     if (amount > 0) {
                         player.setVarbit(LAST_X_INPUT, amount)
                         deposit(player, item.id, amount)
@@ -310,7 +310,7 @@ class BankPlugin(
 
             if (amount == -1) {
                 player.queue(TaskPriority.WEAK) {
-                    amount = inputInt("How many would you like to withdraw?")
+                    amount = inputInt(player, "How many would you like to withdraw?")
                     if (amount > 0) {
                         player.setVarbit(LAST_X_INPUT, amount)
                         withdraw(player, item.id, amount, slot, placehold)

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/chat/ChatBoxFilterPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/chat/ChatBoxFilterPlugin.kt
@@ -12,6 +12,7 @@ import org.alter.game.model.container.*
 import org.alter.game.model.container.key.*
 import org.alter.game.model.entity.*
 import org.alter.game.model.item.*
+import org.alter.game.model.entity.Player
 import org.alter.game.model.queue.*
 import org.alter.game.model.shop.*
 import org.alter.game.model.timer.*
@@ -47,7 +48,7 @@ class ChatBoxFilterPlugin(
                     player.toggleVarbit(26)
                 }
                 2 -> {
-                    player.queue { dialog(this) }
+                    player.queue { dialog(player, this) }
                 }
             }
         }
@@ -96,19 +97,19 @@ class ChatBoxFilterPlugin(
         }
     }
 
-    suspend fun dialog(it: QueueTask) {
+    private suspend fun dialog(player: Player, it: QueueTask) {
         when (
             it.options(
-                "Filter them." /* Filter or unfilter.*/,
+                player, "Filter them." /* Filter or unfilter.*/,
                 "Do not filter them.",
                 title = "Boss kill-counts are not blocked by the spam filter.",
             )
         ) {
             1 -> {
-                it.messageBox("Boss kill-count messages that you receive in future will not be blocked by the spam filter.")
+                it.messageBox(player, "Boss kill-count messages that you receive in future will not be blocked by the spam filter.")
             }
             2 -> {
-                it.messageBox("CBA For now... Later.")
+                it.messageBox(player, "CBA For now... Later.")
             }
         }
     }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/emotes/EmotesTab.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/emotes/EmotesTab.kt
@@ -48,7 +48,7 @@ object EmotesTab {
     ) {
         if (emote.varbit != -1 && p.getVarbit(emote.varbit) != emote.requiredVarbitValue) {
             val description = emote.unlockDescription ?: "You have not unlocked this emote yet."
-            p.queue { messageBox(description) }
+            p.queue { messageBox(p, description) }
             return
         }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/worn_equipment/priceguide/PriceGuide.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/worn_equipment/priceguide/PriceGuide.kt
@@ -164,11 +164,11 @@ object PriceGuide {
     }
 
     suspend fun remove(
+        p: Player,
         it: QueueTask,
         slot: Int,
         opt: Int,
     ) {
-        val p = it.player
         val container = p.attr[GUIDE_CONTAINER] ?: return
         val item = container[slot] ?: return
 
@@ -178,7 +178,7 @@ object PriceGuide {
                 2 -> 5
                 3 -> 10
                 4 -> container.getItemCount(item.id)
-                5 -> it.inputInt()
+                5 -> it.inputInt(p)
                 10 -> {
                     p.world.sendExamine(p, item.id, ExamineEntityType.ITEM)
                     return
@@ -189,11 +189,11 @@ object PriceGuide {
     }
 
     suspend fun add(
+        p: Player,
         it: QueueTask,
         slot: Int,
         opt: Int,
     ) {
-        val p = it.player
         val container = p.attr[TEMP_INV_CONTAINER] ?: return
         val item = container[slot] ?: return
 
@@ -203,7 +203,7 @@ object PriceGuide {
                 2 -> 5
                 3 -> 10
                 4 -> container.getItemCount(item.id)
-                5 -> it.inputInt()
+                5 -> it.inputInt(p)
                 10 -> {
                     p.world.sendExamine(p, item.id, ExamineEntityType.ITEM)
                     return

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/worn_equipment/priceguide/PriceGuidePlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/tabs/worn_equipment/priceguide/PriceGuidePlugin.kt
@@ -46,13 +46,13 @@ class PriceGuidePlugin(
 
         onButton(interfaceId = PRICE_GUIDE_TAB_INTERFACE_ID, component = 0) {
             player.queue(TaskPriority.WEAK) {
-                add(this, player.getInteractingSlot(), player.getInteractingOption())
+                add(player, this, player.getInteractingSlot(), player.getInteractingOption())
             }
         }
 
         onButton(interfaceId = PRICE_GUIDE_INTERFACE_ID, component = 2) {
             player.queue(TaskPriority.WEAK) {
-                remove(this, player.getInteractingSlot(), player.getInteractingOption())
+                remove(player,this, player.getInteractingSlot(), player.getInteractingOption())
             }
         }
 
@@ -62,7 +62,7 @@ class PriceGuidePlugin(
 
         onButton(interfaceId = PRICE_GUIDE_INTERFACE_ID, component = 5) {
             player.queue(TaskPriority.WEAK) {
-                val item = searchItemInput("Select an item to ask about its price:")
+                val item = searchItemInput(player, "Select an item to ask about its price:")
                 search(player, item)
             }
         }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/xpdrops/XpSettingsComponentsPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/gameframe/xpdrops/XpSettingsComponentsPlugin.kt
@@ -150,13 +150,13 @@ class XpSettingsComponentsPlugin(
             when (player.getInteractingOption()) {
                 5 -> {
                     player.queue {
-                        inputInt("Set tracker start point: (skill level)") // If more than 99 it's not valid. "Input is not a valid skill level.
+                        inputInt(player, "Set tracker start point: (skill level)") // If more than 99 it's not valid. "Input is not a valid skill level.
                         // Set varp 261 to xp : so if u input level 80 , it needs to convert into XP
                     }
                 } // Set level
                 6 -> {
                     player.queue {
-                        inputInt("Set tracker start point: (XP value)")
+                        inputInt(player, "Set tracker start point: (XP value)")
                     }
                 }
                 9 ->

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/tournament_supplies/TournamentSuppliesPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/interfaces/tournament_supplies/TournamentSuppliesPlugin.kt
@@ -48,7 +48,7 @@ class TournamentSuppliesPlugin(
                 }
             if (amount == -1) {
                 player.queue(TaskPriority.WEAK) {
-                    amount = inputInt("How many would you like to withdraw?")
+                    amount = inputInt(player, "How many would you like to withdraw?")
                     if (amount > 0) {
                         if (player.inventory.freeSlotCount < amount && !getItem(itemid).stackable
                         ) {

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/items/consumables/prayerscrolls/PrayerScrollsPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/items/consumables/prayerscrolls/PrayerScrollsPlugin.kt
@@ -28,23 +28,23 @@ class PrayerScrollsPlugin(
         onItemOption("item.dexterous_prayer_scroll", "read") {
             player.queue {
                 if (player.getVarbit(Prayers.RIGOUR_UNLOCK_VARBIT) == 1) {
-                    messageBox(
+                    messageBox(player,
                         "You can make out some faded words on the ancient parchment. It appears to be an archaic invocation of the gods. However there's nothing more for you to learn.",
                     )
                     return@queue
                 }
                 player.animate(id = 7403)
-                itemMessageBox(
+                itemMessageBox(player,
                     "You can make out some faded words on the ancient parchment. It appears to be an archaic invocation of the gods! Would you like to absorb its power? <br>(Warning: This will consume the scroll.)</b>",
                     item = "item.dexterous_prayer_scroll",
                 )
-                when (options("Learn Rigour", "Cancel", title = "This will consume the scroll")) {
+                when (options(player, "Learn Rigour", "Cancel", title = "This will consume the scroll")) {
                     1 -> {
                         if (player.inventory.contains(getRSCM("item.dexterous_prayer_scroll"))) {
                             player.inventory.remove(item = "item.dexterous_prayer_scroll")
                             player.setVarbit(id = Prayers.RIGOUR_UNLOCK_VARBIT, value = 1)
                             player.animate(id = -1)
-                            itemMessageBox(
+                            itemMessageBox(player,
                                 "You study the scroll and learn a new prayer: <col=8B0000>Rigour</col>",
                                 item = "item.dexterous_prayer_scroll",
                             )
@@ -60,23 +60,23 @@ class PrayerScrollsPlugin(
         onItemOption("item.arcane_prayer_scroll", "read") {
             player.queue {
                 if (player.getVarbit(Prayers.AUGURY_UNLOCK_VARBIT) == 1) {
-                    messageBox(
+                    messageBox(player,
                         "You can make out some faded words on the ancient parchment. It appears to be an archaic invocation of the gods. However there's nothing more for you to learn.",
                     )
                     return@queue
                 }
                 player.animate(id = 7403)
-                itemMessageBox(
+                itemMessageBox(player,
                     "You can make out some faded words on the ancient parchment. It appears to be an archaic invocation of the gods! Would you like to absorb its power? <br>(Warning: This will consume the scroll.)</b>",
                     item = "item.arcane_prayer_scroll",
                 )
-                when (options("Learn Augury", "Cancel", title = "This will consume the scroll")) {
+                when (options(player, "Learn Augury", "Cancel", title = "This will consume the scroll")) {
                     1 -> {
                         if (player.inventory.contains("item.arcane_prayer_scroll")) {
                             player.inventory.remove(item = "item.arcane_prayer_scroll")
                             player.setVarbit(id = Prayers.AUGURY_UNLOCK_VARBIT, value = 1)
                             player.animate(id = -1)
-                            itemMessageBox(
+                            itemMessageBox(player,
                                 "You study the scroll and learn a new prayer: <col=8B0000>Augury</col>",
                                 item = "item.arcane_prayer_scroll",
                             )
@@ -92,23 +92,23 @@ class PrayerScrollsPlugin(
         onItemOption("item.torn_prayer_scroll", "read") {
             player.queue {
                 if (player.getVarbit(Prayers.PRESERVE_UNLOCK_VARBIT) == 1) {
-                    messageBox(
+                    messageBox(player,
                         "You can make out some faded words on the ancient parchment. It appears to be an archaic invocation of the gods. However there's nothing more for you to learn.",
                     )
                     return@queue
                 }
                 player.animate(id = 7403)
-                itemMessageBox(
+                itemMessageBox(player,
                     "You can make out some faded words on the ancient parchment. It appears to be an archaic invocation of the gods! Would you like to absorb its power? <br>(Warning: This will consume the scroll.)</b>",
                     item = "item.torn_prayer_scroll",
                 )
-                when (options("Learn Preserve", "Cancel", title = "This will consume the scroll")) {
+                when (options(player, "Learn Preserve", "Cancel", title = "This will consume the scroll")) {
                     1 -> {
                         if (player.inventory.contains("item.torn_prayer_scroll")) {
                             player.inventory.remove(item = "item.torn_prayer_scroll")
                             player.setVarbit(id = Prayers.PRESERVE_UNLOCK_VARBIT, value = 1)
                             player.animate(id = -1)
-                            itemMessageBox(
+                            itemMessageBox(player,
                                 "You study the scroll and learn a new prayer: <col=8B0000>Preserve</col>",
                                 item = "item.torn_prayer_scroll",
                             )

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/items/lootingbag/LootingBagPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/items/lootingbag/LootingBagPlugin.kt
@@ -91,7 +91,7 @@ class LootingBagPlugin(
                 player.queue {
                     val container = player.containers[CONTAINER_KEY]
                     val destroy =
-                        destroyItem(
+                        destroyItem(player,
                             note = if (container != null && container.hasAny) "If you destroy it, the contents will be lost." else "The bag is empty. Are you sure you want to destroy it?",
                             item = itmID,
                             amount = 1,
@@ -110,7 +110,7 @@ class LootingBagPlugin(
                 1 -> store(player, slot = slot, amount = 1)
                 2 -> store(player, slot = slot, amount = 5)
                 3 -> store(player, slot = slot, amount = Int.MAX_VALUE)
-                4 -> player.queue { store(player, slot = slot, amount = inputInt()) }
+                4 -> player.queue { store(player, slot = slot, amount = inputInt(player)) }
                 5 -> {
                     val container = player.containers.computeIfAbsent(CONTAINER_KEY) { ItemContainer(CONTAINER_KEY) }
                     val item = container[slot] ?: return@onButton
@@ -133,7 +133,7 @@ class LootingBagPlugin(
                 1 -> bank(player, slot = slot, amount = 1)
                 2 -> bank(player, slot = slot, amount = 5)
                 3 -> bank(player, slot = slot, amount = Int.MAX_VALUE)
-                4 -> player.queue { bank(player, slot = slot, amount = inputInt()) }
+                4 -> player.queue { bank(player, slot = slot, amount = inputInt(player)) }
                 10 -> {
                     val item = player.containers[CONTAINER_KEY]?.get(slot) ?: return@onButton
                     world.sendExamine(player, item.id, ExamineEntityType.ITEM)
@@ -266,7 +266,7 @@ class LootingBagPlugin(
 
     fun settings(p: Player) {
         p.queue {
-            when (options("... ask how many to store.", "... always store as many as possible.", title = "When using items on the bag...")) {
+            when (options(p, "... ask how many to store.", "... always store as many as possible.", title = "When using items on the bag...")) {
                 // TODO: impl effect
                 1 -> {
                     p.message("When using items on the bag, you will be asked how many of that item you wish to store in the bag.")

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/items/spade/SpadePlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/items/spade/SpadePlugin.kt
@@ -31,33 +31,33 @@ class SpadePlugin(
                     player.inventory.remove(23067, 1)
                     player.inventory.add(23068, 1)
                     player.setVarp(2111, 2)
-                    itemMessageBox("You dig up a Treasure Scroll.", item = "item.treasure_scroll_23068")
+                    itemMessageBox(player, "You dig up a Treasure Scroll.", item = "item.treasure_scroll_23068")
                 }
             } else if (player.tile.x == 3202 && player.tile.z == 3211 && player.inventory.contains(getRSCM("item.treasure_scroll_23068"))) {
                 player.queue {
                     player.inventory.remove(23068, 1)
                     player.inventory.add(23069, 1)
                     player.setVarp(2111, 3)
-                    itemMessageBox("You dig up a Mysterious Orb.", item = "item.mysterious_orb_23069")
+                    itemMessageBox(player, "You dig up a Mysterious Orb.", item = "item.mysterious_orb_23069")
                 }
             } else if (player.tile.x == 3108 && player.tile.z == 3264 && player.inventory.contains(getRSCM("item.mysterious_orb_23069"))) {
                 player.queue {
                     player.inventory.remove(23069, 1)
                     player.inventory.add(23070, 1)
                     player.setVarp(2111, 4)
-                    itemMessageBox("You dig up a Treasure Scroll.", item = "item.treasure_scroll_23070")
+                    itemMessageBox(player, "You dig up a Treasure Scroll.", item = "item.treasure_scroll_23070")
                 }
             } else if (player.tile.x == 3077 && player.tile.z == 3260 && player.inventory.contains(getRSCM("item.treasure_scroll_23070"))) {
                 player.queue {
                     player.inventory.remove(23070, 1)
                     player.inventory.add(23071, 1)
                     player.setVarp(2111, 5)
-                    itemMessageBox(
+                    itemMessageBox(player,
                         "You dig up an Ancient Casket. As you do, you hear a<br>faint whispering. You can't make out what it says<br>though...",
                         item = "item.ancient_casket",
                     )
-                    chatPlayer("Hmmmm... Must have been the wind.")
-                    chatPlayer(
+                    chatPlayer(player, "Hmmmm... Must have been the wind.")
+                    chatPlayer(player,
                         "Anyway, this must be the treasure that Veos is after. I<br>should take it to him. If I remember right, he's docked<br>at the northernmost pier in Port Sarim.",
                     )
                 }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/prayer/Prayers.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/prayer/Prayers.kt
@@ -51,15 +51,15 @@ object Prayers {
     }
 
     suspend fun toggle(
+        p: Player,
         it: QueueTask,
         prayer: Prayer,
     ) {
-        val p = it.player
 
         if (p.isDead() || !p.lock.canUsePrayer()) {
             p.syncVarp(ACTIVE_PRAYERS_VARP)
             return
-        } else if (!checkRequirements(it, prayer)) {
+        } else if (!checkRequirements(p, it, prayer)) {
             return
         } else if (prayer.group == PrayerGroup.OVERHEAD && p.timers.has(DISABLE_OVERHEADS)) {
             p.syncVarp(ACTIVE_PRAYERS_VARP)
@@ -167,7 +167,7 @@ object Prayers {
 
         it.player.queue {
             if (!enabled) {
-                if (checkRequirements(this, prayer)) {
+                if (checkRequirements(player,this, prayer)) {
                     val others =
                         Prayer.values.filter { other ->
                             prayer != other && other.group != null &&
@@ -238,45 +238,45 @@ object Prayers {
     ): Boolean = p.getVarbit(prayer.varbit) != 0
 
     private suspend fun checkRequirements(
+        p: Player,
         it: QueueTask,
         prayer: Prayer,
     ): Boolean {
-        val p = it.player
 
         if (p.getSkills().getBaseLevel(Skills.PRAYER) < prayer.level) {
             p.syncVarp(ACTIVE_PRAYERS_VARP)
-            it.messageBox("You need a <col=000080>Prayer</col> level of ${prayer.level} to use <col=000080>${prayer.named}.")
+            it.messageBox(p, "You need a <col=000080>Prayer</col> level of ${prayer.level} to use <col=000080>${prayer.named}.")
             return false
         }
 
         // TODO(Tom): get correct messages for these unlockable
         if (prayer == Prayer.PRESERVE && p.getVarbit(PRESERVE_UNLOCK_VARBIT) == 0) {
             p.syncVarp(ACTIVE_PRAYERS_VARP)
-            it.messageBox("You have not unlocked this prayer.")
+            it.messageBox(p, "You have not unlocked this prayer.")
             return false
         }
 
         if (prayer == Prayer.CHIVALRY && p.getVarbit(KING_RANSOMS_QUEST_VARBIT) < 8) {
             p.syncVarp(ACTIVE_PRAYERS_VARP)
-            it.messageBox("You have not unlocked this prayer.")
+            it.messageBox(p,"You have not unlocked this prayer.")
             return false
         }
 
         if (prayer == Prayer.PIETY && p.getVarbit(KING_RANSOMS_QUEST_VARBIT) < 8) {
             p.syncVarp(ACTIVE_PRAYERS_VARP)
-            it.messageBox("You have not unlocked this prayer.")
+            it.messageBox(p,"You have not unlocked this prayer.")
             return false
         }
 
         if (prayer == Prayer.RIGOUR && p.getVarbit(RIGOUR_UNLOCK_VARBIT) == 0) {
             p.syncVarp(ACTIVE_PRAYERS_VARP)
-            it.messageBox("You have not unlocked this prayer.")
+            it.messageBox(p,"You have not unlocked this prayer.")
             return false
         }
 
         if (prayer == Prayer.AUGURY && p.getVarbit(AUGURY_UNLOCK_VARBIT) == 0) {
             p.syncVarp(ACTIVE_PRAYERS_VARP)
-            it.messageBox("You have not unlocked this prayer.")
+            it.messageBox(p,"You have not unlocked this prayer.")
             return false
         }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/prayer/PrayersPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/prayer/PrayersPlugin.kt
@@ -1,19 +1,9 @@
 package org.alter.plugins.content.mechanics.prayer
 
 import org.alter.api.*
-import org.alter.api.cfg.*
-import org.alter.api.dsl.*
 import org.alter.api.ext.*
 import org.alter.game.*
 import org.alter.game.model.*
-import org.alter.game.model.attr.*
-import org.alter.game.model.container.*
-import org.alter.game.model.container.key.*
-import org.alter.game.model.entity.*
-import org.alter.game.model.item.*
-import org.alter.game.model.queue.*
-import org.alter.game.model.shop.*
-import org.alter.game.model.timer.*
 import org.alter.game.plugin.*
 
 class PrayersPlugin(
@@ -40,7 +30,7 @@ class PrayersPlugin(
         Prayer.values.forEach { prayer ->
             onButton(interfaceId = 541, component = prayer.child) {
                 player.queue {
-                    Prayers.toggle(this, prayer)
+                    Prayers.toggle(player, this, prayer)
                 }
             }
         }

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/trading/TradingPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/mechanics/trading/TradingPlugin.kt
@@ -106,7 +106,7 @@ class TradingPlugin(
                             2 -> 5
                             3 -> 10
                             4 -> inventory.getItemCount(item.id)
-                            5 -> inputInt("Enter amount:")
+                            5 -> inputInt(player, "Enter amount:")
                             else -> 1
                         }
 
@@ -139,7 +139,7 @@ class TradingPlugin(
                             2 -> 5
                             3 -> 10
                             4 -> container.getItemCount(item.id)
-                            5 -> inputInt("Enter amount:")
+                            5 -> inputInt(player, "Enter amount:")
                             else -> 1
                         }
 

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/banker/BankerPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/npcs/banker/BankerPlugin.kt
@@ -1,19 +1,11 @@
 package org.alter.plugins.content.npcs.banker
 
 import org.alter.api.*
-import org.alter.api.cfg.*
-import org.alter.api.dsl.*
 import org.alter.api.ext.*
 import org.alter.game.*
 import org.alter.game.model.*
-import org.alter.game.model.attr.*
-import org.alter.game.model.container.*
-import org.alter.game.model.container.key.*
 import org.alter.game.model.entity.*
-import org.alter.game.model.item.*
 import org.alter.game.model.queue.*
-import org.alter.game.model.shop.*
-import org.alter.game.model.timer.*
 import org.alter.game.plugin.*
 import org.alter.plugins.content.interfaces.bank.openBank
 
@@ -27,7 +19,7 @@ class BankerPlugin(
         arrayOf("npc.banker_1479", "npc.banker_1480").forEach { banker ->
             onNpcOption(npc = banker, option = "talk-to", lineOfSightDistance = 2) {
                 player.queue {
-                    dialog(this)
+                    dialog(player, this)
                 }
             }
             onNpcOption(npc = banker, option = "bank", lineOfSightDistance = 2) {
@@ -39,28 +31,28 @@ class BankerPlugin(
         }
     }
 
-    suspend fun dialog(it: QueueTask) {
-        it.chatNpc("Good day, how may I help you?")
-        when (options(it)) {
-            1 -> it.player.openBank()
-            2 -> open_pin(it.player)
-            3 -> open_collect(it.player)
-            4 -> what_is_this_place(it)
+    suspend fun dialog(player: Player, it: QueueTask) {
+        it.chatNpc(player, "Good day, how may I help you?")
+        when (options(player, it)) {
+            1 -> player.openBank()
+            2 -> open_pin(player)
+            3 -> open_collect(player)
+            4 -> what_is_this_place(player, it)
         }
     }
 
-    suspend fun options(it: QueueTask): Int =
-        it.options(
+    suspend fun options(player: Player, it: QueueTask): Int =
+        it.options(player,
             "I'd like to access my bank account, please.",
             "I'd like to check my PIN settings.",
             "I'd like to collect items.",
             "What is this place?",
         )
 
-    suspend fun what_is_this_place(it: QueueTask) {
-        it.chatNpc("This is a branch of the Bank of Gielinor. We have<br>branches in many towns.", animation = 568)
-        it.chatPlayer("And what do you do?", animation = 554)
-        it.chatNpc(
+    suspend fun what_is_this_place(player: Player, it: QueueTask) {
+        it.chatNpc(player, "This is a branch of the Bank of Gielinor. We have<br>branches in many towns.", animation = 568)
+        it.chatPlayer(player, "And what do you do?", animation = 554)
+        it.chatNpc(player,
             "We will look after your items and money for you.<br>Leave your valuables with us if you want to keep them<br>safe.",
             animation = 569,
         )

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/objects/hay/SearchHayPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/objects/hay/SearchHayPlugin.kt
@@ -58,7 +58,7 @@ class SearchHayPlugin(
                 if (add.hasFailed()) {
                     world.spawn(GroundItem(item = getRSCM("item.needle"), amount = 1, tile = p.tile, owner = p))
                 }
-                it.chatPlayer("Wow! A needle!<br>Now what are the chances of finding that?")
+                it.chatPlayer(p, "Wow! A needle!<br>Now what are the chances of finding that?")
             }
             1 -> {
                 p.hit(damage = 1)

--- a/game-plugins/src/main/kotlin/org/alter/plugins/content/objects/ladder/LadderPlugin.kt
+++ b/game-plugins/src/main/kotlin/org/alter/plugins/content/objects/ladder/LadderPlugin.kt
@@ -115,7 +115,7 @@ class LadderPlugin(
 
     fun climbladder(player: Player) {
         player.queue {
-            when (options("Climb up the ladder.", "Climb down the ladder")) {
+            when (options(player, "Climb up the ladder.", "Climb down the ladder")) {
                 1 -> climbupladder(player)
                 2 -> climbdownladder(player)
             }
@@ -134,7 +134,7 @@ class LadderPlugin(
 
     fun climbstairs(player: Player) {
         player.queue {
-            when (options("Climb up the stairs.", "Climb down the stairs.")) {
+            when (options(player, "Climb up the stairs.", "Climb down the stairs.")) {
                 1 -> climbupstairs(player)
                 2 -> climbdownstairs(player)
             }

--- a/game-server/src/main/kotlin/org/alter/game/model/move/ObjectPathAction.kt
+++ b/game-server/src/main/kotlin/org/alter/game/model/move/ObjectPathAction.kt
@@ -42,7 +42,7 @@ object ObjectPathAction {
                 player.write(SetMapFlag(255, 255))
             }
 
-            val route = walkTo(obj, lineOfSightRange)
+            val route = walkTo(player, obj, lineOfSightRange)
             if (route.success) {
                 if (lineOfSightRange == null || lineOfSightRange > 0) {
                     faceObj(player, obj)
@@ -99,11 +99,10 @@ object ObjectPathAction {
     }
 
     private suspend fun QueueTask.walkTo(
+        pawn: Pawn,
         obj: GameObject,
         lineOfSightRange: Int?,
     ): Route {
-        val pawn = ctx as Pawn
-
         val def = obj.getDef()
         val tile = obj.tile
         val type = obj.type

--- a/game-server/src/main/kotlin/org/alter/game/model/queue/QueueTask.kt
+++ b/game-server/src/main/kotlin/org/alter/game/model/queue/QueueTask.kt
@@ -118,18 +118,16 @@ data class QueueTask(val ctx: Any, val priority: TaskPriority) : Continuation<Un
      * of [Pawn] and that the height of the [tile] and [Pawn.tile] must be equal,
      * as well as the x and z coordinates.
      */
-    suspend fun waitTile(tile: Tile): Unit =
-        suspendCoroutine {
-            nextStep = SuspendableStep(TileCondition((ctx as Pawn).tile, tile), it)
-        }
+    suspend fun waitTile(tile: Tile): Unit {
+        val src = (ctx as Pawn).tile
+        wait { src.sameAs(tile) }
+    }
+
 
     /**
      * Wait for our [ctx] as [Player] to close the [interfaceId].
      */
-    suspend fun waitInterfaceClose(interfaceId: Int): Unit =
-        suspendCoroutine {
-            nextStep = SuspendableStep(PredicateCondition { !(ctx as Player).interfaces.isVisible(interfaceId) }, it)
-        }
+    suspend fun waitInterfaceClose(interfaceId: Int): Unit = wait { !(ctx as Player).interfaces.isVisible(interfaceId) }
 
     /**
      * Wait for <strong>any</strong> return value to be available before

--- a/game-server/src/main/kotlin/org/alter/game/model/queue/coroutine/SuspendableCondition.kt
+++ b/game-server/src/main/kotlin/org/alter/game/model/queue/coroutine/SuspendableCondition.kt
@@ -1,7 +1,6 @@
 package org.alter.game.model.queue.coroutine
 
 import gg.rsmod.util.toStringHelper
-import org.alter.game.model.Tile
 import java.util.concurrent.atomic.AtomicInteger
 
 /**
@@ -29,25 +28,6 @@ class WaitCondition(cycles: Int) : SuspendableCondition() {
     override fun resume(): Boolean = cyclesLeft.decrementAndGet() <= 0
 
     override fun toString(): String = toStringHelper().add("cycles", cyclesLeft).toString()
-}
-
-/**
- * A [SuspendableCondition] that waits for [src] to possess the exact same
- * coordinates as [dst] before permitting the coroutine to continue its logic.
- *
- * Note that the [src] and [dst] can't be the same coordinates if their height
- * does not match as well as their x and z coordinates.
- *
- * @param src
- * The tile that must reach [dst] before the condition returns true.
- *
- * @param dst
- * The tile that must be reached by [dst].
- */
-class TileCondition(private val src: Tile, private val dst: Tile) : SuspendableCondition() {
-    override fun resume(): Boolean = src.sameAs(dst)
-
-    override fun toString(): String = toStringHelper().add("src", src).add("dst", dst).toString()
 }
 
 /**


### PR DESCRIPTION
Cherry picked this from another branch I had that was using the old rsmod2 coroutines.

Idea with this PR is to remove references to ctx within the queuetask itself/coroutine and instead pass the player reference to the relevant methods. Additionally cleaned up the queuetask system abit. This will help with refactoring later to properly set the access scope.

These changes should cleanup the refactoring process later for when coroutines get reworked.

Opened this as a separate PR in case there is discussion or other review that needs done.